### PR TITLE
Remove hardcoded text on `contact` page

### DIFF
--- a/exampleSite/content/contact.md
+++ b/exampleSite/content/contact.md
@@ -3,4 +3,23 @@ title: "Let's, Talk About You"
 description: "this is meta-description"
 layout: "contact"
 draft: false
+
+message: "Let's, Talk About You"
+button_text: "Send Now"
+
+instruction_a: "Send Us A"
+instruction_b: " message"
+
+full_name_title: "Full name"
+full_name_placeholder: "Thomas Milano"
+
+email_title: "Email Address"
+email_placeholder: "example@email.com"
+
+subject_title: "Subject"
+subject_placeholder: "Blog advertisement"
+
+content_title: "Your Message Here"
+content_placeholder: "Hello I’m Mr ‘x’ from.............."
+
 ---

--- a/layouts/_default/contact.html
+++ b/layouts/_default/contact.html
@@ -8,34 +8,34 @@
     <div class="row section-sm pt-0" style="background-image: url('{{ $bgImage.RelPermalink }}')">
       <div class="col-lg-6">
         <div class="content pt-lg-5 pb-3 pb-lg-0">
-          <h2>Let’s Talk About You</h2>
+          <h2>{{ .Params.message | markdownify }}</h2>
         </div>
       </div>
       <div class="col-lg-6">
         <div class="p-4 border rounded-4">
-          <h3 class="h4 mb-5 text-capitalize">Send Us A
-            <span class="text-primary"> message <i class="fas fa-arrow-right ms-2"></i></span>
+          <h3 class="h4 mb-5 text-capitalize">{{ .Params.instruction_a | markdownify }}
+            <span class="text-primary">{{ .Params.instruction_b | markdownify }}<i class="fas fa-arrow-right ms-2"></i></span>
           </h3>
           <form action="{{site.Params.contact_form_action | safeURL}}" method="POST">
             <div class="form-group">
-              <label for="name" class="form-label">Full name <small>*</small></label>
-              <input type="text" class="form-control" name="name" id="name" placeholder="Thomas Milano" required>
+              <label for="name" class="form-label">{{ .Params.full_name_title | markdownify }}<small> *</small></label>
+              <input type="text" class="form-control" name="name" id="name" placeholder="{{ .Params.full_name_placeholder | markdownify }}" required>
             </div>
             <div class="form-group">
-              <label for="email" class="form-label">Email Address <small>*</small></label>
-              <input type="email" name="email" class="form-control" id="email" placeholder="example@email.com" required>
+              <label for="email" class="form-label">{{ .Params.email_title | markdownify }}<small> *</small></label>
+              <input type="email" name="email" class="form-control" id="email" placeholder="{{ .Params.email_placeholder | markdownify }}" required>
             </div>
             <div class="form-group">
-              <label for="name" class="form-label">Subject <small>*</small></label>
-              <input type="text" class="form-control" name="subject" id="subject" placeholder="Blog advertisement"
+              <label for="name" class="form-label">{{ .Params.subject_title | markdownify }}<small> *</small></label>
+              <input type="text" class="form-control" name="subject" id="subject" placeholder="{{ .Params.subject_placeholder | markdownify }}"
                 required>
             </div>
             <div class="form-group">
-              <label for="message" class="form-label">Your Message Here <small>*</small></label>
-              <textarea class="form-control" placeholder="Hello I’m Mr ‘x’ from.............." id="message"
+              <label for="message" class="form-label">{{ .Params.content_title | markdownify }}<small> *</small></label>
+              <textarea class="form-control" placeholder="{{ .Params.content_placeholder | markdownify }}" id="message"
                 name="message" required></textarea>
             </div>
-            <button type="submit" class="btn btn-primary">Send Now</button>
+            <button type="submit" class="btn btn-primary">{{ .Params.button_text | markdownify }}</button>
           </form>
         </div>
       </div>


### PR DESCRIPTION
Fixes hardcoded title text  and helps also when using translations.