### PR TITLE
Update single.html replace deprecated tag

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -39,7 +39,7 @@
         </ul>
         <div class="content drop-cap">{{.Content}}</div>
         <!-- disqus comments -->
-        {{ if .Site.DisqusShortname }}
+        {{ if .Site.Config.Services.Disqus.Shortname }}
         <div class="border rounded p-4">
           {{ template "_internal/disqus.html" . }}
         </div>


### PR DESCRIPTION
.Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.135.0. Use .Site.Config.Services.Disqus.Shortname instead.